### PR TITLE
Upgrade to Laravel 5.5 and set minimum PHP to 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
+  - '7.2'
 
 before_script:
   - travis_retry composer self-update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+### Added
+- Upgraded to Laravel 5.5.
+
+### Removed
+- No longer supports PHP 5.6 and 7.0.
+
+## [2.0.0]
 ### Added
 - Basic integration tests (under PHP 5.6, 7.0 and 7.1).
 - Add change log (`CHANGELOG.md`) and upgrade guide (`UPGRADE.md`).

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/support": "5.4.*",
-        "illuminate/database": "5.4.*"
+        "php": "^7.1.3",
+        "illuminate/support": "5.5.*",
+        "illuminate/database": "5.5.*"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.4",
+        "orchestra/testbench": "^3.5",
         "phpspec/phpspec": "~2.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "psr-4": {
@@ -31,7 +31,15 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "2.x-dev"
+            "dev-develop": "3.x-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Jameswmcnab\\ConfigDb\\ConfigDbServiceProvider"
+            ],
+            "aliases": {
+                "Debugbar": "Jameswmcnab\\ConfigDb\\Facades\\ConfigDb"
+            }
         }
     },
     "minimum-stability": "stable",

--- a/src/ConfigDbServiceProvider.php
+++ b/src/ConfigDbServiceProvider.php
@@ -1,9 +1,7 @@
 <?php namespace Jameswmcnab\ConfigDb;
 
 use Illuminate\Foundation\Application;
-use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
-use Jameswmcnab\ConfigDb\Facades\ConfigDb;
 
 class ConfigDbServiceProvider extends ServiceProvider
 {
@@ -48,12 +46,6 @@ class ConfigDbServiceProvider extends ServiceProvider
         $this->app->singleton('config-db', function (Application $app) {
             return $app->make(RepositoryInterface::class);
         });
-
-        // Add facade alias
-        $this->app->booting(function () {
-            $loader = AliasLoader::getInstance();
-            $loader->alias('ConfigDb', ConfigDb::class);
-        });
     }
 
     /**
@@ -92,6 +84,6 @@ class ConfigDbServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array('config-db');
+        return ['config-db'];
     }
 }


### PR DESCRIPTION
Upgrade to Laravel 5.5 and set the minimum PHP to 7.1

I haven't added any PHP 7 return type hinting to any of the classes, but that's obviously something that could be done.