### PR TITLE
[Refactor] Update service provider container bindings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,11 @@
             "Jameswmcnab\\ConfigDb": "src/"
         }
     },
-    "minimum-stability": "stable"
+    "extra": {
+        "branch-alias": {
+            "dev-1.x": "1.x-dev"
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
 }

--- a/src/Jameswmcnab/ConfigDb/ConfigDbServiceProvider.php
+++ b/src/Jameswmcnab/ConfigDb/ConfigDbServiceProvider.php
@@ -44,7 +44,7 @@ class ConfigDbServiceProvider extends ServiceProvider {
         $this->registerDefaultRepository();
 
         // Register facade accessor
-        $this->app['config-db'] = $this->app->share(function(Application $app)
+        $this->app->singleton('config-db', function(Application $app)
         {
             return $app->make('Jameswmcnab\ConfigDb\RepositoryInterface');
         });
@@ -67,7 +67,7 @@ class ConfigDbServiceProvider extends ServiceProvider {
         $configPath = __DIR__.'/../../config/config-db.php';
         $this->mergeConfigFrom($configPath, 'config-db');
 
-        $this->app->bindShared('Jameswmcnab\ConfigDb\LoaderInterface', function(Application $app)
+        $this->app->singleton('Jameswmcnab\ConfigDb\LoaderInterface', function(Application $app)
         {
             $tableName = $app['config']['config-db.table'];
 
@@ -82,7 +82,7 @@ class ConfigDbServiceProvider extends ServiceProvider {
      */
     protected function registerDefaultRepository()
     {
-        $this->app->bindShared('Jameswmcnab\ConfigDb\RepositoryInterface', function(Application $app)
+        $this->app->singleton('Jameswmcnab\ConfigDb\RepositoryInterface', function(Application $app)
         {
             return new Repository($app->make('Jameswmcnab\ConfigDb\LoaderInterface'));
         });


### PR DESCRIPTION
Use `singleton` for shared bindings as `bindShared` does not exist from Laravel 5.2 onwards and `share` does not exist in Laravel 5.4 onwards.

No need to tag right away - will use the branch alias for the mo.